### PR TITLE
Add Tableau modifications

### DIFF
--- a/plugins/maxcompute_jdbc/connection-dialog.tcd
+++ b/plugins/maxcompute_jdbc/connection-dialog.tcd
@@ -1,9 +1,6 @@
 <connection-dialog class='maxcompute_jdbc'>
   <connection-config>
     <authentication-mode value='Basic' />
-    <authentication-options>
-      <option name="UsernameAndPassword" default="true" />
-    </authentication-options>
-  <has-pre-connect-database value="false" />
+    <has-pre-connect-database value="false" />
   </connection-config>
 </connection-dialog>

--- a/plugins/maxcompute_jdbc/connectionBuilder.js
+++ b/plugins/maxcompute_jdbc/connectionBuilder.js
@@ -1,12 +1,5 @@
 (function dsbuilder(attr) {
-  var username = attr["username"];
-  var password = attr["password"];
-  var connectionString = attr["server"];
-
-  if (!connectionString.endsWith("&")) {
-    connectionString += "&";
-  }
-
-  var params = ["accessId=" + username, "accessKey=" + password];
-  return [connectionString + params.join("&")];
+    var connectionString = "jdbc:odps:" + attr[connectionHelper.attributeServer];
+  
+    return [connectionString];
 })

--- a/plugins/maxcompute_jdbc/connectionProperties.js
+++ b/plugins/maxcompute_jdbc/connectionProperties.js
@@ -1,0 +1,13 @@
+(function propertiesbuilder(attr) {
+    var props = [];  
+    props["accessId"] = attr[connectionHelper.attributeUsername];
+    props["accessKey"] = attr[connectionHelper.attributePassword];
+    
+    var formattedProps = [];
+    for (var key in props)
+    {
+        formattedProps.push(connectionHelper.FormatKeyValuePair(key, props[key]));
+    }
+    
+    return formattedProps;
+})

--- a/plugins/maxcompute_jdbc/connectionResolver.tdr
+++ b/plugins/maxcompute_jdbc/connectionResolver.tdr
@@ -6,13 +6,18 @@
     </connection-builder>
     <connection-normalizer>
       <required-attributes>
+        <setImpersonateAttributes/>
         <attribute-list>
           <attr>class</attr>
           <attr>server</attr>
           <attr>username</attr>
           <attr>password</attr>
+          <attr>one-time-sql</attr>
         </attribute-list>
       </required-attributes>
     </connection-normalizer>
+    <connection-properties>
+        <script file='connectionProperties.js'/>
+    </connection-properties>
   </connection-resolver>
 </tdr>

--- a/plugins/maxcompute_jdbc/manifest.xml
+++ b/plugins/maxcompute_jdbc/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='maxcompute_jdbc' superclass='jdbc' plugin-version='0.0.0' name='MaxCompute' version='1.0'>
-  <connection-customization class="maxcompute_jdbc" enabled="true" version="1.0">
+<connector-plugin class='maxcompute_jdbc' superclass='jdbc' plugin-version='1.1' name='@string/maxcompute/' version='18.1'>
+  <connection-customization class="maxcompute_jdbc" enabled="true" version="18.1">
     <vendor name="vendor"/>
     <driver name="driver"/>
     <customizations>

--- a/plugins/maxcompute_jdbc/resources-en_US.xml
+++ b/plugins/maxcompute_jdbc/resources-en_US.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="maxcompute">Alibaba MaxCompute</string>
+</resources>


### PR DESCRIPTION
This merge request updates the connector plugin files in the repo with the changes we made when integrating the connector into Tableau. Most of these came up when doing our internal tests, or are best practices that were not properly documented on the SDK.

connection-dialog.tcd changes:
Removed the auth-option of username and password, auth mode 'Basic' covers that. See new authenticaiton doc: https://tableau.github.io/connector-plugin-sdk/docs/auth-modes

connectionBuilder and connectionProperties:
For jdbc, we have the connection properties resolver method that builds the jdbc connection string from the properties. While it technically works in the connection builder, there are some unknown repercussions in the Tableau code. We have an item on our backlog to update the postgres jdbc sample with the connection properties model.

connectionResolver.tdr:
Added setImpersoanteAttributes and one-time-sql (which allows for initial sql) to the tdr file. 

manifest.xml:
Added plugin-version number. (It was originally 1.0, but with the username/password update we're bumping it to 1.1). The version tag is for all Tableau xml file and is always 18.1.

Added en_US resource file:
This is for localization, though for this connector the only string is the title, which often isn't localized in Tableau. We wrote new documentation to cover the resource files here: https://tableau.github.io/connector-plugin-sdk/docs/localize.